### PR TITLE
Removing closing parenthesis

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ humandate: Jun 26-26, 2015
 humantime: 9:00 am - 4:30 pm
 startdate: 2015-06-25
 enddate: 2015-06-26
-instructor: ["Brian Miles", "Daniel Chen"])
+instructor: ["Brian Miles", "Daniel Chen"]
 helper: (list of names like ["Marlyn Wescoff", "Fran Bilas", "Ruth Lichterman"])
 contact: gottscott@gmail.com
 etherpad: https://swcarpentry.etherpad.mozilla.org/2015-06-25-jhs


### PR DESCRIPTION
The YAML parser was confused by the unmatched closing paren. Stupid YAML parser.
